### PR TITLE
Increase Speed while playing

### DIFF
--- a/src/main/java/touro/snake/GardenThread.java
+++ b/src/main/java/touro/snake/GardenThread.java
@@ -6,12 +6,17 @@ package touro.snake;
 public class GardenThread extends Thread {
 
     private static final int DELAY_MS = 80;
+    private int currDelay;
+    private int currRound;
+
     private final Garden garden;
     private final GardenView gardenView;
 
     public GardenThread(Garden garden, GardenView gardenView) {
         this.garden = garden;
         this.gardenView = gardenView;
+        currDelay = DELAY_MS;
+        currRound = 0;
     }
 
     /**
@@ -21,9 +26,21 @@ public class GardenThread extends Thread {
         while (garden.advance()) {
             gardenView.repaint();
             try {
-                Thread.sleep(DELAY_MS);
+                decrementTime();
+                Thread.sleep(currDelay);
             } catch (InterruptedException e) {
                 e.printStackTrace();
+            }
+        }
+    }
+
+    public void decrementTime() {
+        if (currDelay > 15) { //the smallest delay allowed
+            if (currRound < 50) {
+                currRound++;
+            } else {
+                currDelay--;
+                currRound = 0;
             }
         }
     }

--- a/src/main/java/touro/snake/GardenThread.java
+++ b/src/main/java/touro/snake/GardenThread.java
@@ -6,8 +6,8 @@ package touro.snake;
 public class GardenThread extends Thread {
 
     private static final int DELAY_MS = 80;
-    private int currDelay;
-    private int currRound;
+    private int currentDelay;
+    private int currentRound;
 
     private final Garden garden;
     private final GardenView gardenView;
@@ -15,8 +15,8 @@ public class GardenThread extends Thread {
     public GardenThread(Garden garden, GardenView gardenView) {
         this.garden = garden;
         this.gardenView = gardenView;
-        currDelay = DELAY_MS;
-        currRound = 0;
+        currentDelay = DELAY_MS;
+        currentRound = 0;
     }
 
     /**
@@ -27,7 +27,7 @@ public class GardenThread extends Thread {
             gardenView.repaint();
             try {
                 decrementTime();
-                Thread.sleep(currDelay);
+                Thread.sleep(currentDelay);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
@@ -35,12 +35,12 @@ public class GardenThread extends Thread {
     }
 
     public void decrementTime() {
-        if (currDelay > 15) { //the smallest delay allowed
-            if (currRound < 50) {
-                currRound++;
+        if (currentDelay > 15) { //the smallest delay allowed
+            if (currentRound < 50) {
+                currentRound++;
             } else {
-                currDelay--;
-                currRound = 0;
+                currentDelay--;
+                currentRound = 0;
             }
         }
     }

--- a/src/main/java/touro/snake/GardenThread.java
+++ b/src/main/java/touro/snake/GardenThread.java
@@ -26,7 +26,7 @@ public class GardenThread extends Thread {
         while (garden.advance()) {
             gardenView.repaint();
             try {
-                decrementTime();
+                decrementDelay();
                 Thread.sleep(currentDelay);
             } catch (InterruptedException e) {
                 e.printStackTrace();
@@ -34,7 +34,7 @@ public class GardenThread extends Thread {
         }
     }
 
-    public void decrementTime() {
+    public void decrementDelay() {
         if (currentDelay > 15) { //the smallest delay allowed
             if (currentRound < 50) {
                 currentRound++;


### PR DESCRIPTION
A problem I ran into when adding this feature was that apparently, `Thread.sleep()` only takes ints. 

Meaning, that the simplest way to solve this problem would be to subtract (for example) .01 from the delay every round. But subtracting one millisecond every time just makes everything too quick too fast. To solve this, I added "rounds" which increment every time the snake moves. On every 50th round, the `currDelay` decrements by one millisecond.